### PR TITLE
Fix: fix path bug in `/migrations` endpoint

### DIFF
--- a/models/migrations.js
+++ b/models/migrations.js
@@ -25,12 +25,12 @@ async function getLast() {
     dbClient = await database.getNewClient();
 
     const options = getMigrationOptions(dbClient, true);
-    
+
     const pendingMigrations = await migrationRunner(options);
 
-    return pendingMigrations
+    return pendingMigrations;
   } catch (err) {
-    console.log(err)
+    console.log(err);
   } finally {
     await dbClient.end();
   }
@@ -40,7 +40,7 @@ function getMigrationOptions(dbClient, isTest) {
   return {
     dbClient: dbClient,
     dryRun: isTest,
-    dir: join("infra", "migrations"),
+    dir: join(process.cwd(), "infra", "migrations"),
     direction: "up",
     verbose: true,
     migrationsTable: "pgmigrations",


### PR DESCRIPTION
When you do a request in /migrations endpoint, it ends in a error, because the Vercel doesn't find the `infra/migrations` path. The problem is in the migration runner options:

```
function getMigrationOptions(dbClient, isTest) {
  return {
    dbClient: dbClient,
    dryRun: isTest,
    dir: join("infra", "migrations"),
    direction: "up",
    verbose: true,
    migrationsTable: "pgmigrations",
  };
}
```

The dir option make a relative path, so instead, we can make an absolute path, using the `process.cwd()` command to get this path:

```
function getMigrationOptions(dbClient, isTest) {
  return {
    dbClient: dbClient,
    dryRun: isTest,
    dir: join(process.cwd(), "infra", "migrations"),
    direction: "up",
    verbose: true,
    migrationsTable: "pgmigrations",
  };
}
```